### PR TITLE
Improve poller to fix frame bug

### DIFF
--- a/lib/services/alarm_polling_worker.dart
+++ b/lib/services/alarm_polling_worker.dart
@@ -42,7 +42,7 @@ class AlarmPollingWorker {
       final foundFiles = await findFiles();
       if (foundFiles.length > 0) return foundFiles[0];
 
-      sleep(Duration(milliseconds: 100));
+      await Future.delayed(const Duration(milliseconds: 100));
     }
 
     return null;


### PR DESCRIPTION
There is a frame bug when launching an app caused by `sleep()`. So I changed it to `Future.delayed()`.